### PR TITLE
Added a check to see if the date about to be parsed is a Date

### DIFF
--- a/src/bootstrap-datepicker-globalize.js
+++ b/src/bootstrap-datepicker-globalize.js
@@ -46,6 +46,7 @@
                 return Globalize.format(date, format);
             },
             parseDate: function (date, format) {
+                if (date instanceof Date) return date; // Can occurs when date is set programmatically by DatePickerRange/setUTCDate(s)
                 return Globalize.parseDate(date, format) || new Date();
             }
         });


### PR DESCRIPTION
Added a check to see if the date about to be parsed by Globalize is already a Date, and if so return the current date without parsing (which would likely return null when trying to parse a UTC date with a format pattern of dd/MM/yyyy).

This fixes an issue where if a date is set programatically by either the DatePickerRange or a call to setUTCDate(s) the new value is ignored and the DatePicker resets to the current date.

---------- To Replicate Issue -----------
1. Setup Globalize with locale like en-GB
2. Add bootstrap-datepicker.js to scripts
3. Add bootstrap-datepicker-globalize.js
4. Add a DatePickerRange to a page.
5. Try use datepicker - selected dates are ignored and today's date is always selected.
